### PR TITLE
TypeError fix

### DIFF
--- a/includes/post/headlineengine-post.php
+++ b/includes/post/headlineengine-post.php
@@ -18,9 +18,12 @@ class HeadlineEnginePost {
     }
 
     public function enqueue_scripts() {
-        if (!in_array(get_post_type(), get_option('headlineengine_post_types'))) {
+        $headlineengine_post_types = get_option('headlineengine_post_types');
+        
+        if ( !$headlineengine_post_types || !in_array( get_post_type(), $headlineengine_post_types ) ) {
             return false;
         }
+
         wp_enqueue_script( "headlineengine-post-script", plugin_dir_url(__FILE__) . "../../dist/headlineengine-gutenberg.js", [], HEADLINEENGINE_SCRIPT_VERSION, true );
         wp_enqueue_style( "headlineengine-post-style", plugin_dir_url(__FILE__) . "../../dist/headlineengine-gutenberg.css", [], HEADLINEENGINE_SCRIPT_VERSION );
         $script = "var headlineengine_readability_range_min = " . intval(get_option('headlineengine_readability_range_min', 45)) . ";";


### PR DESCRIPTION
Check the headlineengine_post_types before checking in_array(). A TypeError gets thrown when trying to access wp-admin when the option doesn't exist.

![headlineengine_undefined_check](https://github.com/MaverickEngine/headline-engine/assets/1118581/4275a360-9ebb-4c75-b05e-302c8695d020)
