### PR TITLE
missing the required permission_callback argument

### DIFF
--- a/includes/api/headlineengine-api.php
+++ b/includes/api/headlineengine-api.php
@@ -9,6 +9,7 @@ class HeadlineEngineAPI {
         register_rest_route( 'headlineengine/v1', '/powerwords', array(
             'methods' => 'GET',
             'callback' => array( $this, 'powerwords' ),
+            'permission_callback' => '__return_true'
         ) );
     }
 


### PR DESCRIPTION
The REST API route definition for crosswordengine/v1/crosswords is missing the required permission_callback argument.